### PR TITLE
feat: add herdr config as stow module

### DIFF
--- a/herdr/.stow-local-ignore
+++ b/herdr/.stow-local-ignore
@@ -1,0 +1,6 @@
+herdr-server\.log
+herdr-client\.log
+herdr-client\.sock
+herdr\.sock
+session\.json
+session-history\.json

--- a/herdr/herdr/config.toml
+++ b/herdr/herdr/config.toml
@@ -1,0 +1,219 @@
+# herdr configuration
+# Place this file at ~/.config/herdr/config.toml
+
+# Show first-run notification setup on startup.
+# Missing also shows onboarding; set false after you've chosen.
+onboarding = false
+
+[theme]
+# Built-in themes: catppuccin, terminal, tokyo-night, dracula, nord,
+#                  gruvbox, one-dark, solarized, kanagawa, rose-pine,
+#                  vesper
+name = "terminal"
+
+# Override individual color tokens on top of the base theme.
+# Accepts: hex (#rrggbb), named colors, rgb(r,g,b), or panel_bg = "reset"
+# [theme.custom]
+panel_bg = "reset"
+# accent = "#f5c2e7"
+# red = "#ff6188"
+# green = "#a6e3a1"
+
+[terminal]
+# Executable used for new interactive panes.
+# Empty means $SHELL, then /bin/sh.
+# default_shell = ""
+
+# Startup mode for new interactive pane shells: "auto", "login", or "non_login".
+# "auto" uses login shells on macOS and keeps the current behavior elsewhere.
+# shell_mode = "auto"
+
+# CWD policy for new panes, tabs, and workspaces when no explicit --cwd is provided.
+# Use "follow" to inherit the source pane/workspace, "home" for $HOME,
+# "current" for Herdr's process directory, or a fixed path such as "~/Projects".
+new_cwd = "follow"
+
+[update]
+# Update channel used by background checks and `herdr update`.
+# Use "stable" for normal releases or "preview" for opt-in preview builds.
+channel = "stable"
+
+[keys]
+# Prefix key to enter prefix mode (default: "ctrl+b")
+# Examples: "ctrl+b", "f12", "esc", "-"
+# Action bindings use explicit syntax: "prefix+n" requires the prefix;
+# "ctrl+alt+n" is a direct terminal-mode shortcut.
+# Accepted key syntax: plain keys, ctrl/shift/alt/cmd/super modifiers, and special keys like enter/tab/esc/left/right/up/down.
+# Named punctuation such as minus, comma, ampersand, plus, and backtick is also accepted.
+# Most reliable direct bindings are ctrl+letter, function keys, and explicit modified chords.
+# alt+..., cmd/super, and punctuation-with-modifiers may depend on your terminal/tmux setup.
+prefix = "ctrl+b"
+
+# Pane navigation (direct, no prefix needed)
+# C-S-hjkl for herdr panes; C-hjkl pass through to vim splits
+focus_pane_left = "ctrl+shift+h"
+focus_pane_down = "ctrl+shift+j"
+focus_pane_up = "ctrl+shift+k"
+focus_pane_right = "ctrl+shift+l"
+
+# Tab switching (H/L for prev/next, backtick for last active)
+previous_tab = "prefix+H"
+next_tab = "prefix+L"
+last_pane = "prefix+backtick"
+
+# Split (matches tmux: - for vertical, | for horizontal)
+split_vertical = "prefix+backslash"
+split_horizontal = "prefix+minus"
+
+# Workspace management
+workspace_picker = "prefix+f"
+new_workspace = "prefix+C"
+
+# Reload config (tmux muscle memory)
+reload_config = "prefix+r"
+
+# Resize mode
+resize_mode = "prefix+shift+r"
+
+# Edit scrollback
+edit_scrollback = "prefix+e"
+
+# Other prefix-mode actions (keeping defaults)
+help = "prefix+?"
+detach = "prefix+q"
+new_tab = "prefix+c"
+rename_tab = "prefix+shift+t"
+switch_tab = "prefix+1..9"
+close_tab = "prefix+shift+x"
+close_pane = "prefix+x"
+zoom = "prefix+z"
+toggle_sidebar = "prefix+b"
+rename_workspace = "prefix+shift+w"
+close_workspace = "prefix+shift+d"
+
+# Navigate-mode movement. These local shortcuts win while navigate mode is open.
+# They are independent from focus_pane_*. Do not include prefix+, esc, enter, tab, or 1..9 here.
+navigate_pane_left = "h"
+navigate_pane_down = "j"
+navigate_pane_up = "k"
+navigate_pane_right = "l"
+
+# [worktrees]
+# directory = "~/.herdr/worktrees"
+
+[ui]
+# Sidebar width (auto-scaled based on workspace names, this sets the default)
+# sidebar_width = 26
+
+# Minimum sidebar width when expanded (columns)
+# sidebar_min_width = 18
+
+# Maximum sidebar width when expanded (columns)
+# sidebar_max_width = 36
+
+# Terminal width at or below which Herdr uses the mobile single-column layout.
+# Increase this for foldables, tablets, or wide phone terminals.
+# mobile_width_threshold = 64
+
+# Capture mouse input for Herdr's mouse UI.
+# Set false to let the terminal handle normal clicks, such as Cmd-clicking URLs.
+# Pane apps like lazygit and btop can still receive mouse when they request it.
+mouse_capture = true
+
+# Optional modifier that forwards right-click hold/drag gestures to pane apps instead of opening Herdr's pane menu.
+# Empty/off disables this. Shift is intentionally unsupported because terminals commonly reserve Shift+mouse.
+# right_click_passthrough_modifier = ""
+
+# Force a full redraw when the outer terminal regains focus.
+# Set false to reduce visible flashing when switching back to Herdr.
+# Trade-off: rare host terminal surface corruption may persist until the next full redraw.
+# redraw_on_focus_gained = true
+
+# Pane scrollback lines to scroll per mouse wheel notch.
+# mouse_scroll_lines = 3
+
+# Ask for confirmation before closing a workspace
+# confirm_close = true
+
+# Ask for a tab name before creating a new tab.
+# Set false to create tabs immediately with generated names.
+prompt_new_tab_name = true
+
+# Show detected/reported agent labels in split pane borders when no manual pane name is set.
+show_agent_labels_on_pane_borders = true
+
+# Agent panel scope: "current" or "all". Toggling it in the sidebar saves this setting.
+agent_panel_scope = "all"
+
+# Accent color for highlights, borders, and navigation UI.
+# Accepts: hex (#89b4fa), named colors (cyan, blue, magenta), or rgb(r,g,b)
+accent = "cyan"
+
+# Background notification popup delivery
+[ui.toast]
+# off = disable pop-up notifications
+# herdr = show top-right in-app toasts
+# terminal = ask the outer terminal to show a desktop notification
+# system = ask the OS notification service directly
+delivery = "system"
+
+# Play sounds when agents change state in background workspaces
+[ui.sound]
+enabled = true
+# Optional custom mp3 sound files. Relative paths are resolved from this config file's directory.
+# path = "sounds/notification.mp3"   # one mp3 file for all sound notifications
+# done_path = "sounds/done.mp3"      # overrides only finished notifications
+# request_path = "sounds/request.mp3" # overrides only needs-attention notifications
+
+# Per-agent overrides: default | on | off
+# By default, droid is muted.
+# [ui.sound.agents]
+# droid = "off"
+
+[session]
+# Resume supported AI-agent panes into their native conversation sessions after
+# a Herdr server restart. Requires official integrations that report session refs.
+# resume_agents_on_restore = true
+
+[remote]
+# Whether herdr manages the ssh config used for the `herdr --remote` bridge.
+# When true (default), herdr runs the bridge ssh through a generated config that
+# includes your ~/.ssh/config first and adds ServerAliveInterval/
+# ServerAliveCountMax as a fallback (so any keepalive you set yourself still
+# wins) to survive idle network/NAT timeouts. Set false to run plain ssh against
+# your ssh config unchanged — this does not force keepalive off, it only stops
+# herdr from adding its own.
+# manage_ssh_config = true
+
+[experimental]
+# Allow launching herdr from inside a herdr-managed pane.
+# allow_nested = false
+# Experimental local Kitty graphics rendering for attached clients.
+# Requires a Kitty graphics-compatible outer terminal.
+# kitty_graphics = false
+# Save recent pane screen history across full server restarts.
+pane_history = true
+# While prefix mode is active, temporarily switch the macOS host input
+# source to an ASCII-capable keyboard layout so prefix commands register
+# even when a CJK IME is active, then restore the previous input source
+# when prefix mode exits. macOS only; best-effort. Default: false.
+switch_ascii_input_source_in_prefix = true
+# Expose the focused pane's cursor to the outer terminal so macOS input
+# methods keep tracking the candidate window when TUIs paint their own
+# cursor (Claude Code, pi, codex). Trade-off: extra cursor visible for
+# apps that hide it without painting a replacement (vim normal mode, etc.).
+# reveal_hidden_cursor_for_cjk_ime = false
+# Optional allow-list: only reveal for focused panes whose detected agent
+# matches one of these names. Empty means apply to any focused pane.
+# If the list contains no valid names, the reveal does not apply.
+# Accepted: pi, claude, codex, gemini, cursor, cline, opencode, copilot,
+# kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder.
+# cjk_ime_agents = []
+# Cursor shape rendered when reveal_hidden_cursor_for_cjk_ime is true.
+# Values: block, steady_block (default), underline, steady_underline, bar, steady_bar.
+# cjk_ime_cursor_shape = "steady_block"
+
+[advanced]
+# Maximum scrollback buffer size in bytes retained per pane terminal.
+# Matches Ghostty's default scrollback-limit behavior.
+scrollback_limit_bytes = 10000000

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ CONFIG_DIR="${HOME}/.config"
 HOME_DIR="${HOME}"
 
 # Define modules and their targets
-modules=("zshrc" "tmux" "alacritty" "nvim" "local" "mise" "spaceship" "bat")
+modules=("zshrc" "tmux" "alacritty" "nvim" "local" "mise" "spaceship" "bat" "herdr")
 
 # Show help message
 show_help() {
@@ -77,7 +77,7 @@ get_target_dir() {
 	"zshrc" | "tmux" | "local" | "spaceship")
 		echo "$HOME_DIR"
 		;;
-	"alacritty" | "nvim" | "mise" | "bat")
+	"alacritty" | "nvim" | "mise" | "bat" | "herdr")
 		echo "$CONFIG_DIR"
 		;;
 	*)


### PR DESCRIPTION
Add herdr terminal multiplexer config to dotfiles managed by GNU Stow.

- `herdr/herdr/config.toml` — full herdr config (theme, keys, UI, session settings)
- `.stow-local-ignore` — excludes runtime files (logs, sockets, session data)
- Registered `herdr` module in `install.sh` targeting `~/.config`